### PR TITLE
Write parquet file with log parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ uv pip install -r requirements.txt
 
 ## Running the Parser
 
-Execute the log parser with PySpark to display the parsed fields:
+Execute the log parser with PySpark to parse the log file and write the
+results to a Parquet file:
 
 ```bash
-python scripts/parse_logs_spark.py data/access_log_sample.txt
+python scripts/parse_logs_spark.py data/access_log_sample.txt parsed_logs.parquet
 ```
+
+If the output path is omitted, the file `parsed_logs.parquet` is created in the
+current directory.
 
 ## Running the Unit Tests
 

--- a/parse_logs_spark.py
+++ b/parse_logs_spark.py
@@ -23,9 +23,11 @@ def parse_logs(spark, log_file):
 def main(argv=None):
     argv = argv or sys.argv[1:]
     log_file = argv[0] if argv else 'access_log_sample.txt'
+    output_file = argv[1] if len(argv) > 1 else 'parsed_logs.parquet'
     spark = create_spark_session('LogParser')
     logs_df = parse_logs(spark, log_file)
     logs_df.show(truncate=False)
+    logs_df.write.mode("overwrite").parquet(output_file)
     spark.stop()
 
 

--- a/scripts/parse_logs_spark.py
+++ b/scripts/parse_logs_spark.py
@@ -6,9 +6,11 @@ from log_analysis import parser
 def main(argv=None):
     argv = argv or sys.argv[1:]
     log_file = argv[0] if argv else 'data/access_log_sample.txt'
+    output_file = argv[1] if len(argv) > 1 else 'parsed_logs.parquet'
     spark = create_spark_session('LogParser')
     logs_df = parser.parse_logs(spark, log_file)
     logs_df.show(truncate=False)
+    logs_df.write.mode("overwrite").parquet(output_file)
     spark.stop()
 
 


### PR DESCRIPTION
## Summary
- allow specifying an output path in `parse_logs_spark.py`
- save the parsed logs as a parquet file
- document parquet output in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyspark')*

------
https://chatgpt.com/codex/tasks/task_b_68475bac4970832eacc197fa550b55b7